### PR TITLE
Add CLI optiom to specify a different delimiter for the CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Flags
   -i, --input string     XML input file path or directory or url
   -m, --mapping string   XML to CSV mapping file path or url
   -o, --output string    CSV output file path
+  -d, --delimiter string   CSV output delimiter (e.g. ';' or '\t' for tab) (default ",")
   -b, --bom              CSV with BOM
   -h, --help             Help
 ```


### PR DESCRIPTION
As per the description, this commit add the following option:
```
-d, --delimiter string`,   CSV output delimiter (e.g. ';' or '\t' for tab) (default ",")
```

Example:
* Semicolon-separated file:
```
./xml2csv -d ';' -b -m mapping.json -i sitemap-00001.xml -o sitemap-00001.csv
```
Input:
[sitemap-00001.xml](https://assets.grokipedia.com/sitemap/sitemap-00001.xml)

Output:
```
page;lastmod;changefreq;priority
https://grokipedia.com/page/!!;2025-10-27;weekly;0.8
https://grokipedia.com/page/!!!;2025-10-27;weekly;0.8
https://grokipedia.com/page/!Oka_Tokat;2025-10-27;weekly;0.8
https://grokipedia.com/page/!_(Trippie_Redd_album);2025-10-27;weekly;0.8
https://grokipedia.com/page/!_(disambiguation);2025-10-27;weekly;0.8
```

* Tab-separated file:
```
./xml2csv -d '\t' -b -m mapping.json -i sitemap-00001.xml -o sitemap-00001.csv
```
Output:
```
page  lastmod changefreq  priority
https://grokipedia.com/page/!!  2025-10-27  weekly  0.8
https://grokipedia.com/page/!!! 2025-10-27  weekly  0.8
https://grokipedia.com/page/!Oka_Tokat  2025-10-27  weekly  0.8
https://grokipedia.com/page/!_(Trippie_Redd_album)  2025-10-27  weekly  0.8
https://grokipedia.com/page/!_(disambiguation)  2025-10-27  weekly  0.8
```