### PR TITLE
feat: add Homebrew and Scoop installation support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,3 +42,5 @@ jobs:
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,3 +35,25 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+
+brews:
+  - name: xml2csv
+    repository:
+      owner: onozaty
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    description: "xml2csv converts XML to CSV. You can easily define mappings for converts using XPath."
+    homepage: "https://github.com/onozaty/xml2csv"
+    license: MIT
+    skip_upload: auto
+
+scoops:
+  - name: xml2csv
+    repository:
+      owner: onozaty
+      name: scoop-bucket
+      token: "{{ .Env.SCOOP_BUCKET_TOKEN }}"
+    description: "xml2csv converts XML to CSV. You can easily define mappings for converts using XPath."
+    homepage: "https://github.com/onozaty/xml2csv"
+    license: MIT
+    skip_upload: auto

--- a/README.md
+++ b/README.md
@@ -91,9 +91,22 @@ Please refer to the sample below.
 
 ## Install
 
-You can download the binary from the following.
+### Homebrew (macOS/Linux)
 
-* https://github.com/onozaty/xml2csv/releases/latest
+```bash
+brew install onozaty/tap/xml2csv
+```
+
+### Scoop (Windows)
+
+```bash
+scoop bucket add onozaty https://github.com/onozaty/scoop-bucket
+scoop install xml2csv
+```
+
+### Binary Download
+
+Download the latest binary from [GitHub Releases](https://github.com/onozaty/xml2csv/releases/latest).
 
 ## License
 


### PR DESCRIPTION
## Summary
- Configure GoReleaser to publish to `onozaty/homebrew-tap` for Homebrew support
- Configure GoReleaser to publish to `onozaty/scoop-bucket` for Scoop support
- Add required environment variables (`HOMEBREW_TAP_TOKEN` and `SCOOP_BUCKET_TOKEN`) to release workflow
- Update README with Homebrew and Scoop installation instructions