### PR TITLE
fix: migrate from brews to homebrew_casks

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,7 @@ changelog:
       - '^docs:'
       - '^test:'
 
-brews:
+homebrew_casks:
   - repository:
       owner: onozaty
       name: homebrew-tap


### PR DESCRIPTION
- Replace deprecated `brews` with `homebrew_casks`